### PR TITLE
adds joi for validators and validator tests

### DIFF
--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const { expect } = require("chai");
+const { number } = require("joi");
+const Joi = require("joi");
+
+const MovieValidator = require("../../lib/validators/movie");
+
+describe("movie validator", () => {
+  describe("title", () => {
+    it("is required", () => {
+        const payload = {};
+        const result = Joi.validate(payload, MovieValidator)
+
+        expect(result.error.details[0].path[0]).to.eql('title');
+        expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it("is less than 255 characters", () => {
+        const payload = { title: 'a'.repeat(260) };
+        const result = Joi.validate(payload, MovieValidator)
+        
+        expect(result.error.details[0].path[0]).to.eql('title');
+        expect(result.error.details[0].type).to.eql('string.max');
+    });
+  });
+
+  describe("release_year", () => {
+    it("is after 1878", () => {
+        const payload = {
+            title: 'foo',
+            release_year: 1800
+        };
+        const result = Joi.validate(payload, MovieValidator);
+
+        expect(result.error.details[0].path[0]).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it("is limited to 4 digits", () => {
+        const payload = {
+            title: 'foo',
+            release_year: 12345
+        };
+
+        const result = Joi.validate(payload, MovieValidator);
+
+        expect(result.error.details[0].path[0]).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.max');
+    });
+  });
+});


### PR DESCRIPTION
Adds Joi, a Hapi library for validating javascript objects. 

Adds validators for movie title to require a title, and that it is between 1 and 255 characters long. And movie release year. It must be 4 number long and after 1878

Add validator testing for movie that all requirements are met. 