### PR TITLE
fixes migration for adding name column to movies, backfills name column

### DIFF
--- a/db/migrations/20210813191349_add_name_to_movies.js
+++ b/db/migrations/20210813191349_add_name_to_movies.js
@@ -2,14 +2,14 @@
 
 exports.up = async (Knex) => {
   await Knex.schema.table('movies', (table) => {
-      table.text('name');
-  })
+    table.text('name');
+  });
   await Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
 };
 
 exports.down = async (Knex) => {
   await Knex.schema.table('movies', (table) => {
-      table.dropColumn('name');
-  })
-    await Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL')
+    table.dropColumn('name');
+  });
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
 };

--- a/db/migrations/20210813192317_backfill_movies_name.js
+++ b/db/migrations/20210813192317_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+	return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};


### PR DESCRIPTION
fixes the migration for adding name. An older migration was stopping name from being added to table and caused an error when trying to backfill name column.